### PR TITLE
Allow string emoji sizes

### DIFF
--- a/src/utils/shared-props.js
+++ b/src/utils/shared-props.js
@@ -16,7 +16,7 @@ const EmojiPropTypes = {
   sheetColumns: PropTypes.number,
   sheetRows: PropTypes.number,
   set: PropTypes.oneOf(['apple', 'google', 'twitter', 'facebook']),
-  size: PropTypes.number.isRequired,
+  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   emoji: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
 }
 


### PR DESCRIPTION
This allows for other sizes (1rem, 1em, 10%) in addition to the current numerical sizes, which are treated as px.

Although this does support em and %, note that they don't render as expected:
- The .emoji-mart-emoji class sets font-size to 0, which results in any em value resolving to 0.
- % based sizes will be weird, since the parent span doesn't have an explicit size.